### PR TITLE
feat: make private regex more robust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl Preprocessor for Private {
         }
 
         lazy_static! {
-            static ref RE: Regex = Regex::new(r"<!--\s*private\b((?s).*?)-->").unwrap();
+            static ref RE: Regex = Regex::new(r"<!--\s*private\b\s*[\r?\n]?((?s).*?)[\r?\n]?\s*-->").unwrap();
         }
 
         book.for_each_mut(|item: &mut BookItem| {
@@ -264,4 +264,181 @@ mod test {
         let actual_book = result.unwrap();
         assert_eq!(actual_book, expected_book);
     }
+
+    #[test]
+    fn private_remove_robustly_run() {
+        let input_json = r##"[
+                {
+                    "root": "/path/to/book",
+                    "config": {
+                        "book": {
+                            "authors": ["AUTHOR"],
+                            "language": "en",
+                            "multilingual": false,
+                            "src": "src",
+                            "title": "TITLE"
+                        },
+                        "preprocessor": {
+                            "private": {
+                                "remove": true
+                            }
+                        }
+                    },
+                    "renderer": "html",
+                    "mdbook_version": "0.4.21"
+                },
+                {
+                    "sections": [
+                        {
+                            "Chapter": {
+                                "name": "Chapter 1",
+                                "content": "# Chapter 1\n<!--private Hello world! -->\nThe End",
+                                "number": [1],
+                                "sub_items": [],
+                                "path": "chapter_1.md",
+                                "source_path": "chapter_1.md",
+                                "parent_names": []
+                            }
+                        }
+                    ],
+                    "__non_exhaustive": null
+                }
+            ]"##;
+        let output_json = r##"[
+                {
+                    "root": "/path/to/book",
+                    "config": {
+                        "book": {
+                            "authors": ["AUTHOR"],
+                            "language": "en",
+                            "multilingual": false,
+                            "src": "src",
+                            "title": "TITLE"
+                        },
+                        "preprocessor": {
+                            "private": {
+                                "remove": true
+                            }
+                        }
+                    },
+                    "renderer": "html",
+                    "mdbook_version": "0.4.21"
+                },
+                {
+                    "sections": [
+                        {
+                            "Chapter": {
+                                "name": "Chapter 1",
+                                "content": "# Chapter 1\n\nThe End",
+                                "number": [1],
+                                "sub_items": [],
+                                "path": "chapter_1.md",
+                                "source_path": "chapter_1.md",
+                                "parent_names": []
+                            }
+                        }
+                    ],
+                    "__non_exhaustive": null
+                }
+            ]"##;
+        let input_json = input_json.as_bytes();
+        let output_json = output_json.as_bytes();
+
+        let (ctx, book) = mdbook::preprocess::CmdPreprocessor::parse_input(input_json).unwrap();
+        let (_, expected_book) =
+            mdbook::preprocess::CmdPreprocessor::parse_input(output_json).unwrap();
+
+        let result = Private::new().run(&ctx, book);
+        assert!(result.is_ok());
+
+        let actual_book = result.unwrap();
+        assert_eq!(actual_book, expected_book);
+    }
+
+    #[test]
+    fn private_keep_robustly_run() {
+        let input_json = r##"[
+                {
+                    "root": "/path/to/book",
+                    "config": {
+                        "book": {
+                            "authors": ["AUTHOR"],
+                            "language": "en",
+                            "multilingual": false,
+                            "src": "src",
+                            "title": "TITLE"
+                        },
+                        "preprocessor": {
+                            "private": {}
+                        }
+                    },
+                    "renderer": "html",
+                    "mdbook_version": "0.4.21"
+                },
+                {
+                    "sections": [
+                        {
+                            "Chapter": {
+                                "name": "Chapter 1",
+                                "content": "# Chapter 1\n<!--private Hello world! -->\nThe End",
+                                "number": [1],
+                                "sub_items": [],
+                                "path": "chapter_1.md",
+                                "source_path": "chapter_1.md",
+                                "parent_names": []
+                            }
+                        }
+                    ],
+                    "__non_exhaustive": null
+                }
+            ]"##;
+        let output_json = r##"[
+                {
+                    "root": "/path/to/book",
+                    "config": {
+                        "book": {
+                            "authors": ["AUTHOR"],
+                            "language": "en",
+                            "multilingual": false,
+                            "src": "src",
+                            "title": "TITLE"
+                        },
+                        "preprocessor": {
+                            "private": {}
+                        }
+                    },
+                    "renderer": "html",
+                    "mdbook_version": "0.4.21"
+                },
+                {
+                    "sections": [
+                        {
+                            "Chapter": {
+                                "name": "Chapter 1",
+                                "content": "# Chapter 1\n<blockquote style='position: relative; padding: 20px 20px;'><span style='position: absolute; top: 0; right: 5px; font-size: 80%; opacity: 0.4;'>CONFIDENTIAL</span>Hello world!</blockquote>\nThe End",
+                                "number": [1],
+                                "sub_items": [],
+                                "path": "chapter_1.md",
+                                "source_path": "chapter_1.md",
+                                "parent_names": []
+                            }
+                        }
+                    ],
+                    "__non_exhaustive": null
+                }
+            ]"##;
+        let input_json = input_json.as_bytes();
+        let output_json = output_json.as_bytes();
+
+        let (ctx, book) = mdbook::preprocess::CmdPreprocessor::parse_input(input_json).unwrap();
+        let (_, expected_book) =
+            mdbook::preprocess::CmdPreprocessor::parse_input(output_json).unwrap();
+
+        let result = Private::new().run(&ctx, book);
+        assert!(result.is_ok());
+
+        let actual_book = result.unwrap();
+        assert_eq!(actual_book, expected_book);
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl Preprocessor for Private {
         }
 
         lazy_static! {
-            static ref RE: Regex = Regex::new(r"<!--private[\r?\n]((?s).*?)[\r?\n]-->").unwrap();
+            static ref RE: Regex = Regex::new(r"<!--\s*private\b((?s).*?)-->").unwrap();
         }
 
         book.for_each_mut(|item: &mut BookItem| {


### PR DESCRIPTION
I found some private data leaking to the web. So adjusted the regular expression to make it less likely in future.
Handles cases like:

<!--private one line section-->

<!-- private
left a gap between the comment start and private
-->

And any trailing whitespace on the first line too.